### PR TITLE
run go mod init

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/detectify/ugly-duckling
+
+go 1.15


### PR DESCRIPTION
Go 1.16 defaults to Go module mode; the future Go 1.17 will remove the GOPATH mode entirely.